### PR TITLE
fix menu for pingreducer

### DIFF
--- a/PingReducer.lua
+++ b/PingReducer.lua
@@ -30,7 +30,7 @@ local function OnCreateMove()
 end
 
 local function OnUnload()
-    MenuLib.RemoveMenu(menu)
+    MenuLib.RemoveMenu(Menu)
 
     client.Command('play "ui/buttonclickrelease"', true)
 end


### PR DESCRIPTION
fix `Menu.lua:1028: attempt to index a nil value (local 'menu')` when trying to unload pingreducer